### PR TITLE
fix(deps): override vulnerable transitive deps flagged by Dependabot

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3698,9 +3698,9 @@
       }
     },
     "node_modules/@module-federation/dts-plugin/node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
@@ -7358,9 +7358,9 @@
       }
     },
     "node_modules/@vercel/frameworks/node_modules/js-yaml": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
@@ -7368,18 +7368,6 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
-      }
-    },
-    "node_modules/@vercel/frameworks/node_modules/smol-toml": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.5.2.tgz",
-      "integrity": "sha512-QlaZEqcAH3/RtNyet1IPIYPsEWAaYyXXv1Krsi+1L/QHppjX4Ifm8MQsBISz9vE8cHicIq3clogsheili5vhaQ==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">= 18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/cyyynthia"
       }
     },
     "node_modules/@vercel/stega": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,15 @@
     "globals": "17.9.0",
     "prettier": "3.9.6"
   },
+  "overrides": {
+    "@vercel/frameworks": {
+      "js-yaml": "3.15.1",
+      "smol-toml": "1.7.1"
+    },
+    "@module-federation/dts-plugin": {
+      "undici": "7.29.0"
+    }
+  },
   "prettier": {
     "semi": false,
     "singleQuote": true,


### PR DESCRIPTION
Closes the open Dependabot alerts on this repo. All of them came from transitive dependencies under `sanity` / `@sanity/cli` — none from our direct dependencies — so they're fixed with `overrides` rather than dependency bumps.

## Changes

| Package | Path | Before | After | Alerts |
|---|---|---|---|---|
| `js-yaml` | `@vercel/frameworks` | 3.13.1 | 3.15.1 | #157 (high), #155, #104 |
| `smol-toml` | `@vercel/frameworks` | 1.5.2 | 1.7.1 | #127 |
| `undici` | `@module-federation/dts-plugin` | 7.28.0 | 7.29.0 | #162 (high), #163–#166 |

`smol-toml` now dedupes to the root copy, so the nested `node_modules` entry disappears entirely.

Alerts #143 aside (see below), the rest of the reported alerts were already resolved by recent Renovate bumps and should auto-close on the next scan: root `undici` 6.28.0, root `smol-toml` 1.7.1, root `uuid` 11.1.1, and `jsdom` / `isomorphic-dompurify` → `undici` 7.29.0.

`npm audit` goes from **2 high + 12 moderate → 5 moderate**.

## Deliberately not fixed

**#143 — `uuid` 10.0.0 under `typeid-js`.** The patched version is 11.1.1, but `typeid-js` requests `^10`, so this would be a forced major bump across a package that changed its export surface. The vulnerability is a missing buffer bounds check on the optional `buf` argument to v3/v5/v6, which `typeid-js` does not pass. Better to wait for `typeid-js` to widen its range upstream.

## Risk

Low. All three overrides are in-range patch/minor bumps, and all four issues are DoS / parsing / cache-poisoning bugs in CLI and build-time code paths (`@vercel/frameworks` backs `sanity deploy` framework detection; `@module-federation/dts-plugin` is build-only). None are reachable from the deployed studio, and none see untrusted input in this project.

Note: `npm audit fix` proposes *downgrading* `sanity` to 5.14.1 as its "fix" — don't run it on this repo.

## Verification

- `npm run lint:tsc` ✅
- `npm run lint:eslint` ✅
- `npm run lint:prettier` ✅
- `npm run build` ✅

`sanity deploy` was not exercised — it's the one path that actually loads `@vercel/frameworks`, though the change there is a patch-level bump within 3.x.

🤖 Generated with [Claude Code](https://claude.com/claude-code)